### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/actions/build-n-cache-image/action.yml
+++ b/.github/actions/build-n-cache-image/action.yml
@@ -26,7 +26,7 @@ runs:
         - name: Emit image tag
           id: emit
           shell: bash
-          run: echo "tag=posthog/posthog:${{ github.sha }}" >> $GITHUB_OUTPUT
+          run: echo "tag=posthog/posthog:${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
         - name: Build image # We don't push this because we use Depot cache as the communication channel
           id: build

--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -57,7 +57,7 @@ runs:
           run: |
               git fetch --no-tags --prune --depth=1 origin
               changed=$(git diff --quiet HEAD origin/master -- hogql_parser/ && echo "false" || echo "true")
-              echo "changed=$changed" >> $GITHUB_OUTPUT
+              echo "changed=$changed" >> "$GITHUB_OUTPUT"
 
         - name: Install SAML (python3-saml) dependencies
           shell: bash

--- a/.github/workflows/build-hogql-parser.yml
+++ b/.github/workflows/build-hogql-parser.yml
@@ -52,7 +52,7 @@ jobs:
                       curl -s -u posthog-bot:${{ secrets.POSTHOG_BOT_GITHUB_TOKEN || secrets.GITHUB_TOKEN }} -X POST -d "{ \"body\": \"$message_body\" }" "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"
                     fi
                   fi
-                  echo "::set-output name=parser-release-needed::$parser_release_needed"
+                  echo "parser-release-needed=$parser_release_needed" >> $GITHUB_OUTPUT
 
     build-wheels:
         name: Build wheels on ${{ matrix.os }}

--- a/.github/workflows/build-hogql-parser.yml
+++ b/.github/workflows/build-hogql-parser.yml
@@ -52,7 +52,7 @@ jobs:
                       curl -s -u posthog-bot:${{ secrets.POSTHOG_BOT_GITHUB_TOKEN || secrets.GITHUB_TOKEN }} -X POST -d "{ \"body\": \"$message_body\" }" "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"
                     fi
                   fi
-                  echo "parser-release-needed=$parser_release_needed" >> $GITHUB_OUTPUT
+                  echo "parser-release-needed=$parser_release_needed" >> "$GITHUB_OUTPUT"
 
     build-wheels:
         name: Build wheels on ${{ matrix.os }}

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -286,10 +286,10 @@ jobs:
               run: |
                   if [[ -z $(git status -s | grep -v ".test_durations" | tr -d "\n") ]]
                   then
-                    echo 'files_found=false' >> $GITHUB_OUTPUT
+                    echo 'files_found=false' >> "$GITHUB_OUTPUT"
                   else
-                    echo 'diff=$(git status --porcelain)' >> $GITHUB_OUTPUT
-                    echo 'files_found=true' >> $GITHUB_OUTPUT
+                    echo 'diff=$(git status --porcelain)' >> "$GITHUB_OUTPUT"
+                    echo 'files_found=true' >> "$GITHUB_OUTPUT"
                   fi
 
             - name: Fail CI if some snapshots have been updated but not committed

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -66,7 +66,7 @@ jobs:
 
             - name: Group spec files into chunks of three
               id: chunk
-              run: echo "chunks=$(ls cypress/e2e/* | jq --slurp --raw-input -c 'split("\n")[:-1] | _nwise(2) | join("\n")' | jq --slurp -c .)" >> $GITHUB_OUTPUT
+              run: echo "chunks=$(ls cypress/e2e/* | jq --slurp --raw-input -c 'split("\n")[:-1] | _nwise(2) | join("\n")' | jq --slurp -c .)" >> "$GITHUB_OUTPUT"
 
     container:
         name: Build and cache container image
@@ -128,12 +128,12 @@ jobs:
             - name: Get pnpm cache directory path
               if: needs.changes.outputs.shouldTriggerCypress == 'true'
               id: pnpm-cache-dir
-              run: echo "PNPM_STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+              run: echo "PNPM_STORE_PATH=$(pnpm store path)" >> "$GITHUB_OUTPUT"
 
             - name: Get cypress cache directory path
               if: needs.changes.outputs.shouldTriggerCypress == 'true'
               id: cypress-cache-dir
-              run: echo "CYPRESS_BIN_PATH=$(npx cypress cache path)" >> $GITHUB_OUTPUT
+              run: echo "CYPRESS_BIN_PATH=$(npx cypress cache path)" >> "$GITHUB_OUTPUT"
 
             - uses: actions/cache@v3
               if: needs.changes.outputs.shouldTriggerCypress == 'true'

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -73,7 +73,7 @@ jobs:
             - name: Get pnpm cache directory path
               if: needs.changes.outputs.frontend == 'true'
               id: pnpm-cache-dir
-              run: echo "PNPM_STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+              run: echo "PNPM_STORE_PATH=$(pnpm store path)" >> "$GITHUB_OUTPUT"
 
             - uses: actions/cache@v3
               if: needs.changes.outputs.frontend == 'true'

--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -98,7 +98,7 @@ jobs:
             - name: Check for changes in plugins directory
               id: check_changes_plugins
               run: |
-                  echo "::set-output name=changed::$(git diff --name-only HEAD^ HEAD | grep '^plugin-server/' || true)"
+                  echo "changed=$(git diff --name-only HEAD^ HEAD | grep '^plugin-server/' || true)" >> $GITHUB_OUTPUT
 
             - name: Trigger Ingestion Cloud deployment
               if: steps.check_changes_plugins.outputs.changed != ''
@@ -116,7 +116,7 @@ jobs:
             - name: Check for changes that affect batch exports temporal worker
               id: check_changes_batch_exports_temporal_worker
               run: |
-                  echo "::set-output name=changed::$(git diff --name-only HEAD^ HEAD | grep -E '^posthog/temporal/common|^posthog/temporal/batch_exports|^posthog/batch_exports/|^posthog/management/commands/start_temporal_worker.py$' || true)"
+                  echo "changed=$(git diff --name-only HEAD^ HEAD | grep -E '^posthog/temporal/common|^posthog/temporal/batch_exports|^posthog/batch_exports/|^posthog/management/commands/start_temporal_worker.py$' || true)" >> $GITHUB_OUTPUT
 
             - name: Trigger Batch Exports Temporal Worker Cloud deployment
               if: steps.check_changes_batch_exports_temporal_worker.outputs.changed != ''
@@ -135,7 +135,7 @@ jobs:
             - name: Check for changes that affect data warehouse temporal worker
               id: check_changes_data_warehouse_temporal_worker
               run: |
-                  echo "::set-output name=changed::$(git diff --name-only HEAD^ HEAD | grep -E '^posthog/temporal/common|^posthog/temporal/data_imports|^posthog/warehouse/|^posthog/management/commands/start_temporal_worker.py$' || true)"
+                  echo "changed=$(git diff --name-only HEAD^ HEAD | grep -E '^posthog/temporal/common|^posthog/temporal/data_imports|^posthog/warehouse/|^posthog/management/commands/start_temporal_worker.py$' || true)" >> $GITHUB_OUTPUT
 
             - name: Trigger Data Warehouse Temporal Worker Cloud deployment
               if: steps.check_changes_data_warehouse_temporal_worker.outputs.changed != ''

--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -98,7 +98,7 @@ jobs:
             - name: Check for changes in plugins directory
               id: check_changes_plugins
               run: |
-                  echo "changed=$(git diff --name-only HEAD^ HEAD | grep '^plugin-server/' || true)" >> $GITHUB_OUTPUT
+                  echo "changed=$(git diff --name-only HEAD^ HEAD | grep '^plugin-server/' || true)" >> "$GITHUB_OUTPUT"
 
             - name: Trigger Ingestion Cloud deployment
               if: steps.check_changes_plugins.outputs.changed != ''
@@ -116,7 +116,7 @@ jobs:
             - name: Check for changes that affect batch exports temporal worker
               id: check_changes_batch_exports_temporal_worker
               run: |
-                  echo "changed=$(git diff --name-only HEAD^ HEAD | grep -E '^posthog/temporal/common|^posthog/temporal/batch_exports|^posthog/batch_exports/|^posthog/management/commands/start_temporal_worker.py$' || true)" >> $GITHUB_OUTPUT
+                  echo "changed=$(git diff --name-only HEAD^ HEAD | grep -E '^posthog/temporal/common|^posthog/temporal/batch_exports|^posthog/batch_exports/|^posthog/management/commands/start_temporal_worker.py$' || true)" >> "$GITHUB_OUTPUT"
 
             - name: Trigger Batch Exports Temporal Worker Cloud deployment
               if: steps.check_changes_batch_exports_temporal_worker.outputs.changed != ''
@@ -135,7 +135,7 @@ jobs:
             - name: Check for changes that affect data warehouse temporal worker
               id: check_changes_data_warehouse_temporal_worker
               run: |
-                  echo "changed=$(git diff --name-only HEAD^ HEAD | grep -E '^posthog/temporal/common|^posthog/temporal/data_imports|^posthog/warehouse/|^posthog/management/commands/start_temporal_worker.py$' || true)" >> $GITHUB_OUTPUT
+                  echo "changed=$(git diff --name-only HEAD^ HEAD | grep -E '^posthog/temporal/common|^posthog/temporal/data_imports|^posthog/warehouse/|^posthog/management/commands/start_temporal_worker.py$' || true)" >> "$GITHUB_OUTPUT"
 
             - name: Trigger Data Warehouse Temporal Worker Cloud deployment
               if: steps.check_changes_data_warehouse_temporal_worker.outputs.changed != ''

--- a/.github/workflows/lint-new-pr.yml
+++ b/.github/workflows/lint-new-pr.yml
@@ -21,9 +21,9 @@ jobs:
                   )
                   echo "::debug::Filtered PR body to $FILTERED_BODY"
                   if [[ -z "${FILTERED_BODY//[[:space:]]/}" ]]; then
-                      echo "is-shame-worthy=true" >> $GITHUB_OUTPUT
+                      echo "is-shame-worthy=true" >> "$GITHUB_OUTPUT"
                   else
-                      echo "is-shame-worthy=false" >> $GITHUB_OUTPUT
+                      echo "is-shame-worthy=false" >> "$GITHUB_OUTPUT"
                   fi
               env:
                   RAW_BODY: ${{ github.event.pull_request.body }}

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -95,7 +95,7 @@ jobs:
                   kubectl -n $NAMESPACE delete -f .github/pr-deploy/hobby.yaml || true
                   kubectl -n $NAMESPACE apply -f .github/pr-deploy/hobby.yaml
 
-                  echo "url=$HOSTNAME.dev.posthog.dev" >> $GITHUB_OUTPUT
+                  echo "url=$HOSTNAME.dev.posthog.dev" >> "$GITHUB_OUTPUT"
 
             - name: update deployment status
               uses: bobheadxi/deployments@v1

--- a/.github/workflows/storybook-chromatic.yml
+++ b/.github/workflows/storybook-chromatic.yml
@@ -199,10 +199,10 @@ jobs:
                     fi
                   fi
 
-                  echo "${{ matrix.browser }}-${{ matrix.shard }}-added=$ADDED" >> $GITHUB_OUTPUT
-                  echo "${{ matrix.browser }}-${{ matrix.shard }}-modified=$MODIFIED" >> $GITHUB_OUTPUT
-                  echo "${{ matrix.browser }}-${{ matrix.shard }}-deleted=$DELETED" >> $GITHUB_OUTPUT
-                  echo "${{ matrix.browser }}-${{ matrix.shard }}-total=$TOTAL" >> $GITHUB_OUTPUT
+                  echo "${{ matrix.browser }}-${{ matrix.shard }}-added=$ADDED" >> "$GITHUB_OUTPUT"
+                  echo "${{ matrix.browser }}-${{ matrix.shard }}-modified=$MODIFIED" >> "$GITHUB_OUTPUT"
+                  echo "${{ matrix.browser }}-${{ matrix.shard }}-deleted=$DELETED" >> "$GITHUB_OUTPUT"
+                  echo "${{ matrix.browser }}-${{ matrix.shard }}-total=$TOTAL" >> "$GITHUB_OUTPUT"
 
             - name: Commit updated snapshots
               uses: EndBug/add-and-commit@v9
@@ -218,7 +218,7 @@ jobs:
             - name: Add commit hash to outputs, including browser name
               id: commit-hash
               if: steps.commit.outputs.pushed == 'true'
-              run: echo "${{ matrix.browser }}-${{ matrix.shard }}-commitHash=${{ steps.commit.outputs.commit_long_sha }}" >> $GITHUB_OUTPUT
+              run: echo "${{ matrix.browser }}-${{ matrix.shard }}-commitHash=${{ steps.commit.outputs.commit_long_sha }}" >> "$GITHUB_OUTPUT"
 
     visual-regression-summary:
         name: Summarize visual regression tests

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -51,7 +51,7 @@ jobs:
 
             - name: Set commit message
               id: commit-message
-              run: echo "msg=Storybook build for ${{ github.sha }}" >> $GITHUB_OUTPUT
+              run: echo "msg=Storybook build for ${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
             - name: Commit update
               uses: stefanzweifel/git-auto-commit-action@v4


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


